### PR TITLE
fix: update todo app URL to joes-todo-app.vercel.app

### DIFF
--- a/apps/landing-page/src/app/project-links.tsx
+++ b/apps/landing-page/src/app/project-links.tsx
@@ -12,7 +12,7 @@ const LOCAL_JOE_BOT_PORT = 3010;
 const LOCAL_TODO_PORT = 3012;
 // Update fallbacks if Vercel project names differ from these defaults
 const FALLBACK_JOE_BOT_URL = 'https://joe-bot.vercel.app';
-const FALLBACK_TODO_APP_URL = 'https://hello-ai-todo-app.vercel.app';
+const FALLBACK_TODO_APP_URL = 'https://joes-todo-app.vercel.app';
 
 function isLocalHost(hostname: string) {
   return hostname === 'localhost' || hostname === '127.0.0.1';


### PR DESCRIPTION
Updates landing page fallback URL for todo app after Vercel project rename.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single constant change that only affects the landing page’s production fallback link when `NEXT_PUBLIC_TODO_APP_URL` isn’t set.
> 
> **Overview**
> Updates the landing page `ProjectLinks` production fallback for the Todo App link from `hello-ai-todo-app.vercel.app` to `joes-todo-app.vercel.app`, reflecting a Vercel project rename. Behavior when `NEXT_PUBLIC_TODO_APP_URL` is set or when running on localhost is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cba3436e762db56a56f1008d7658bdcde68b24d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->