### PR TITLE
feat: e2e tests for all projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   main:
     runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.58.2-noble
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,9 +35,6 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps
 
       - uses: nrwl/nx-set-shas@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+
       - uses: nrwl/nx-set-shas@v4
 
       - run: pnpm nx affected -t lint test build e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,6 @@ jobs:
 
       - uses: nrwl/nx-set-shas@v4
 
-      - run: pnpm nx affected -t lint test build
+      - run: pnpm nx affected -t lint test build e2e
       - run: pnpm nx fix-ci
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
+
+      - name: Set git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,16 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref || 'main' }}
+
       - uses: nrwl/nx-set-shas@v4
+
+      - name: Set NX_BASE fallback
+        run: |
+          if [ -z "${NX_BASE}" ]; then
+            echo "NX_BASE=origin/${{ github.base_ref || 'main' }}" >> $GITHUB_ENV
+          fi
 
       - run: pnpm nx affected -t lint test build e2e
       - run: pnpm nx fix-ci

--- a/apps/joe-bot-e2e/playwright.config.ts
+++ b/apps/joe-bot-e2e/playwright.config.ts
@@ -27,42 +27,44 @@ export default defineConfig({
     command: 'pnpm exec nx run @hello-ai/joe-bot:dev',
     url: 'http://localhost:3010',
     reuseExistingServer: true,
+    timeout: process.env.CI ? 180000 : 60000,
     cwd: workspaceRoot,
   },
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
+  projects:
+    process.env.CI
+      ? [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }]
+      : [
+          {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+          },
+          {
+            name: 'firefox',
+            use: { ...devices['Desktop Firefox'] },
+          },
+          {
+            name: 'webkit',
+            use: { ...devices['Desktop Safari'] },
+          },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
+          // Uncomment for mobile browsers support
+          /* {
+            name: 'Mobile Chrome',
+            use: { ...devices['Pixel 5'] },
+          },
+          {
+            name: 'Mobile Safari',
+            use: { ...devices['iPhone 12'] },
+          }, */
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    // Uncomment for mobile browsers support
-    /* {
-      name: 'Mobile Chrome',
-      use: { ...devices['Pixel 5'] },
-    },
-    {
-      name: 'Mobile Safari',
-      use: { ...devices['iPhone 12'] },
-    }, */
-
-    // Uncomment for branded browsers
-    /* {
-      name: 'Microsoft Edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    },
-    {
-      name: 'Google Chrome',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    } */
-  ],
+          // Uncomment for branded browsers
+          /* {
+            name: 'Microsoft Edge',
+            use: { ...devices['Desktop Edge'], channel: 'msedge' },
+          },
+          {
+            name: 'Google Chrome',
+            use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+          } */
+        ],
 });

--- a/apps/joe-bot-e2e/playwright.config.ts
+++ b/apps/joe-bot-e2e/playwright.config.ts
@@ -3,7 +3,7 @@ import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
 
 // For CI, you may want to set BASE_URL to the deployed application.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:3000';
+const baseURL = process.env['BASE_URL'] || 'http://localhost:3010';
 
 /**
  * Read environment variables from file.
@@ -24,8 +24,8 @@ export default defineConfig({
   },
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'pnpm exec nx run @hello-ai/joe-bot:start',
-    url: 'http://localhost:3000',
+    command: 'pnpm exec nx run @hello-ai/joe-bot:dev',
+    url: 'http://localhost:3010',
     reuseExistingServer: true,
     cwd: workspaceRoot,
   },

--- a/apps/joe-bot-e2e/src/example.spec.ts
+++ b/apps/joe-bot-e2e/src/example.spec.ts
@@ -1,8 +1,17 @@
 import { test, expect } from '@playwright/test';
 
-test('has title', async ({ page }) => {
+test('shows chat UI', async ({ page }) => {
   await page.goto('/');
 
-  // Expect h1 to contain a substring.
-  expect(await page.locator('h1').innerText()).toContain('Welcome');
+  await expect(page.locator('h1')).toContainText('Joe-bot');
+});
+
+test('has chat input and send controls', async ({ page }) => {
+  await page.goto('/');
+
+  const textarea = page.getByPlaceholder(/Ask anything/);
+  await expect(textarea).toBeVisible();
+
+  const sendButton = page.getByRole('button', { name: /Send/i });
+  await expect(sendButton).toBeVisible();
 });

--- a/apps/joe-bot/tsconfig.spec.json
+++ b/apps/joe-bot/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "jsx": "preserve",

--- a/apps/landing-page/e2e/example.spec.ts
+++ b/apps/landing-page/e2e/example.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('shows Current Projects heading', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.locator('h1')).toContainText('Current Projects');
+});
+
+test('has links to Joe-bot and Todo App', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.locator('h2:has-text("Joe-bot")')).toBeVisible();
+  await expect(page.locator('h2:has-text("Todo App")')).toBeVisible();
+});

--- a/apps/landing-page/playwright.config.ts
+++ b/apps/landing-page/playwright.config.ts
@@ -3,7 +3,7 @@ import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
 
 // For CI, you may want to set BASE_URL to the deployed application.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:3012';
+const baseURL = process.env['BASE_URL'] || 'http://localhost:3011';
 
 /**
  * Read environment variables from file.
@@ -15,7 +15,7 @@ const baseURL = process.env['BASE_URL'] || 'http://localhost:3012';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  ...nxE2EPreset(__filename, { testDir: './src' }),
+  ...nxE2EPreset(__filename, { testDir: './e2e' }),
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     baseURL,
@@ -24,8 +24,8 @@ export default defineConfig({
   },
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'pnpm exec nx run @hello-ai/todo-app:dev',
-    url: 'http://localhost:3012',
+    command: 'pnpm exec nx run @hello-ai/landing-page:dev',
+    url: 'http://localhost:3011',
     reuseExistingServer: true,
     cwd: workspaceRoot,
   },

--- a/apps/landing-page/playwright.config.ts
+++ b/apps/landing-page/playwright.config.ts
@@ -27,42 +27,44 @@ export default defineConfig({
     command: 'pnpm exec nx run @hello-ai/landing-page:dev',
     url: 'http://localhost:3011',
     reuseExistingServer: true,
+    timeout: process.env.CI ? 180000 : 60000,
     cwd: workspaceRoot,
   },
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
+  projects:
+    process.env.CI
+      ? [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }]
+      : [
+          {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+          },
+          {
+            name: 'firefox',
+            use: { ...devices['Desktop Firefox'] },
+          },
+          {
+            name: 'webkit',
+            use: { ...devices['Desktop Safari'] },
+          },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
+          // Uncomment for mobile browsers support
+          /* {
+            name: 'Mobile Chrome',
+            use: { ...devices['Pixel 5'] },
+          },
+          {
+            name: 'Mobile Safari',
+            use: { ...devices['iPhone 12'] },
+          }, */
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    // Uncomment for mobile browsers support
-    /* {
-      name: 'Mobile Chrome',
-      use: { ...devices['Pixel 5'] },
-    },
-    {
-      name: 'Mobile Safari',
-      use: { ...devices['iPhone 12'] },
-    }, */
-
-    // Uncomment for branded browsers
-    /* {
-      name: 'Microsoft Edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    },
-    {
-      name: 'Google Chrome',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    } */
-  ],
+          // Uncomment for branded browsers
+          /* {
+            name: 'Microsoft Edge',
+            use: { ...devices['Desktop Edge'], channel: 'msedge' },
+          },
+          {
+            name: 'Google Chrome',
+            use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+          } */
+        ],
 });

--- a/apps/landing-page/tsconfig.e2e.json
+++ b/apps/landing-page/tsconfig.e2e.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "outDir": "out-tsc/playwright",
+    "sourceMap": false
+  },
+  "include": ["e2e/**/*.ts", "e2e/**/*.js", "playwright.config.ts"],
+  "exclude": ["out-tsc", "test-output"]
+}

--- a/apps/landing-page/tsconfig.json
+++ b/apps/landing-page/tsconfig.json
@@ -35,6 +35,9 @@
   "references": [
     {
       "path": "../../shared"
+    },
+    {
+      "path": "./tsconfig.e2e.json"
     }
   ],
   "exclude": [

--- a/apps/todo-app-e2e/playwright.config.ts
+++ b/apps/todo-app-e2e/playwright.config.ts
@@ -28,42 +28,44 @@ export default defineConfig({
     command: 'pnpm exec nx run @hello-ai/todo-app:dev',
     url: 'http://localhost:3012',
     reuseExistingServer: true,
+    timeout: process.env.CI ? 180000 : 60000,
     cwd: workspaceRoot,
   },
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
+  projects:
+    process.env.CI
+      ? [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }]
+      : [
+          {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+          },
+          {
+            name: 'firefox',
+            use: { ...devices['Desktop Firefox'] },
+          },
+          {
+            name: 'webkit',
+            use: { ...devices['Desktop Safari'] },
+          },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
+          // Uncomment for mobile browsers support
+          /* {
+            name: 'Mobile Chrome',
+            use: { ...devices['Pixel 5'] },
+          },
+          {
+            name: 'Mobile Safari',
+            use: { ...devices['iPhone 12'] },
+          }, */
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    // Uncomment for mobile browsers support
-    /* {
-      name: 'Mobile Chrome',
-      use: { ...devices['Pixel 5'] },
-    },
-    {
-      name: 'Mobile Safari',
-      use: { ...devices['iPhone 12'] },
-    }, */
-
-    // Uncomment for branded browsers
-    /* {
-      name: 'Microsoft Edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    },
-    {
-      name: 'Google Chrome',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    } */
-  ],
+          // Uncomment for branded browsers
+          /* {
+            name: 'Microsoft Edge',
+            use: { ...devices['Desktop Edge'], channel: 'msedge' },
+          },
+          {
+            name: 'Google Chrome',
+            use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+          } */
+        ],
 });

--- a/apps/todo-app-e2e/src/example.spec.ts
+++ b/apps/todo-app-e2e/src/example.spec.ts
@@ -1,8 +1,33 @@
 import { test, expect } from '@playwright/test';
 
-test('has title', async ({ page }) => {
+test('shows Todos heading', async ({ page }) => {
   await page.goto('/');
 
-  // Expect h1 to contain a substring.
-  expect(await page.locator('h1').innerText()).toContain('Welcome');
+  await expect(page.locator('h1')).toContainText('Todos');
+});
+
+test('can add a todo', async ({ page }) => {
+  await page.goto('/');
+
+  const input = page.getByPlaceholder('What needs to be done?');
+  await input.fill('Buy milk');
+  await page.getByRole('button', { name: 'Add' }).click();
+
+  await expect(page.locator('text=Buy milk')).toBeVisible();
+});
+
+test('can toggle todo completion', async ({ page }) => {
+  await page.goto('/');
+
+  const input = page.getByPlaceholder('What needs to be done?');
+  await input.fill('Walk the dog');
+  await page.getByRole('button', { name: 'Add' }).click();
+
+  const todoItem = page.locator('text=Walk the dog');
+  await expect(todoItem).toBeVisible();
+
+  const toggleButton = page.getByRole('button', { name: 'Mark complete' });
+  await toggleButton.click();
+
+  await expect(page.getByRole('button', { name: 'Mark incomplete' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
Adds and fixes e2e tests for joe-bot, todo-app, and landing-page.

## Changes
- **joe-bot-e2e**: Fix port (3010), use dev server, add chat UI tests
- **todo-app-e2e**: Fix port (3012), add todo add/toggle tests
- **landing-page**: Add e2e (Current Projects heading, Joe-bot/Todo App links)
- **CI**: Add e2e to affected targets (lint, test, build, e2e)

## Verification
- joe-bot-e2e: 6 passed
- todo-app-e2e: 9 passed
- landing-page e2e: 6 passed

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI pipeline behavior changes and new Playwright E2E runs can introduce longer runtimes and CI-only flakiness, but changes are isolated to test/CI configuration rather than production code paths.
> 
> **Overview**
> Adds Playwright E2E coverage across the monorepo and wires it into CI.
> 
> CI now runs inside a Playwright container and executes `pnpm nx affected -t lint test build e2e`, with extra git/Nx base-branch setup to make `affected` calculations work reliably.
> 
> E2E configs/tests are updated and expanded: `joe-bot-e2e` switches to the dev server on port `3010` and adds basic chat UI checks; `todo-app-e2e` adds flow tests for adding/toggling todos and adds CI-friendly server timeouts; `landing-page` gains a new Playwright config + smoke tests plus TS config references to compile/run E2E tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89daf0f36f1c7c4abe27c784b53ddfbab26566c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->