### PR TITLE
feat: Add Home button to joe-bot and todo-app

### DIFF
--- a/apps/joe-bot-e2e/src/example.spec.ts
+++ b/apps/joe-bot-e2e/src/example.spec.ts
@@ -3,6 +3,15 @@ import { test, expect } from '@playwright/test';
 test('has title', async ({ page }) => {
   await page.goto('/');
 
-  // Expect h1 to contain a substring.
-  expect(await page.locator('h1').innerText()).toContain('Welcome');
+  expect(await page.locator('h1').innerText()).toContain('Joe-bot');
+});
+
+test('has Home link in header', async ({ page }) => {
+  await page.goto('/');
+
+  const homeLink = page.getByRole('link', { name: 'Home' });
+  await homeLink.waitFor({ state: 'visible', timeout: 10000 });
+
+  await expect(homeLink).toBeVisible();
+  await expect(homeLink).toHaveAttribute('href', /.+/);
 });

--- a/apps/joe-bot/src/app/page.tsx
+++ b/apps/joe-bot/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
-import { Button, Loader } from '@hello-ai/shared-ui';
+import { Button, HomeLink, Loader } from '@hello-ai/shared-ui';
 import { tokens } from '@hello-ai/shared-design';
 
 type ChatMsg = {
@@ -186,6 +186,7 @@ export default function Page() {
           </div>
 
           <div className="flex items-center gap-2">
+            <HomeLink />
             <Button
               onClick={clearChat}
               variant="secondary"

--- a/apps/todo-app-e2e/playwright.config.ts
+++ b/apps/todo-app-e2e/playwright.config.ts
@@ -3,7 +3,8 @@ import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
 
 // For CI, you may want to set BASE_URL to the deployed application.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:3000';
+// todo-app dev runs on port 3012 (see apps/todo-app/project.json)
+const baseURL = process.env['BASE_URL'] || 'http://localhost:3012';
 
 /**
  * Read environment variables from file.
@@ -25,7 +26,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'pnpm exec nx run @hello-ai/todo-app:dev',
-    url: 'http://localhost:3000',
+    url: 'http://localhost:3012',
     reuseExistingServer: true,
     cwd: workspaceRoot,
   },

--- a/apps/todo-app-e2e/src/example.spec.ts
+++ b/apps/todo-app-e2e/src/example.spec.ts
@@ -3,6 +3,13 @@ import { test, expect } from '@playwright/test';
 test('has title', async ({ page }) => {
   await page.goto('/');
 
-  // Expect h1 to contain a substring.
-  expect(await page.locator('h1').innerText()).toContain('Welcome');
+  expect(await page.locator('h1').innerText()).toContain('Todos');
+});
+
+test('has Home link in header', async ({ page }) => {
+  await page.goto('/');
+
+  const homeLink = page.getByRole('link', { name: 'Home' });
+  await expect(homeLink).toBeVisible();
+  await expect(homeLink).toHaveAttribute('href', /.+/);
 });

--- a/apps/todo-app/src/app/page.tsx
+++ b/apps/todo-app/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Button } from '@hello-ai/shared-ui';
+import { Button, HomeLink } from '@hello-ai/shared-ui';
 import { tokens } from '@hello-ai/shared-design';
 import { useTodos, type TodoFilter } from '@hello-ai/todo-data-access';
 
@@ -20,10 +20,15 @@ export default function Index() {
     <main className="min-h-[100dvh] bg-zinc-950 text-zinc-100">
       <div className="mx-auto w-full max-w-lg px-4 py-8">
         <header className="mb-6">
-          <div className="text-xs uppercase tracking-wider text-zinc-500">
-            HELLO-AI / todo-app
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-xs uppercase tracking-wider text-zinc-500">
+                HELLO-AI / todo-app
+              </div>
+              <h1 className="text-2xl font-semibold tracking-tight">Todos</h1>
+            </div>
+            <HomeLink />
           </div>
-          <h1 className="text-2xl font-semibold tracking-tight">Todos</h1>
         </header>
 
         <form

--- a/libs/shared/ui/src/home-link.tsx
+++ b/libs/shared/ui/src/home-link.tsx
@@ -16,8 +16,11 @@ export function HomeLink() {
   );
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && isLocalHost(window.location.hostname)) {
-      setUrl(`http://${window.location.hostname}:${LOCAL_LANDING_PORT}`);
+    const w = typeof globalThis !== 'undefined' && 'location' in globalThis
+      ? (globalThis as unknown as { location: { hostname: string } }).location
+      : null;
+    if (w && isLocalHost(w.hostname)) {
+      setUrl(`http://${w.hostname}:${LOCAL_LANDING_PORT}`);
     }
   }, []);
 

--- a/libs/shared/ui/src/home-link.tsx
+++ b/libs/shared/ui/src/home-link.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const LOCAL_LANDING_PORT = 3011;
+const FALLBACK_LANDING_URL = 'https://hello-ai-landing-page.vercel.app';
+
+function isLocalHost(hostname: string) {
+  return hostname === 'localhost' || hostname === '127.0.0.1';
+}
+
+export function HomeLink() {
+  const [url, setUrl] = useState(
+    () =>
+      process.env.NEXT_PUBLIC_LANDING_PAGE_URL || FALLBACK_LANDING_URL
+  );
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && isLocalHost(window.location.hostname)) {
+      setUrl(`http://${window.location.hostname}:${LOCAL_LANDING_PORT}`);
+    }
+  }, []);
+
+  return (
+    <a
+      href={url}
+      className="inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-700"
+    >
+      <span aria-hidden>⌂</span>
+      Home
+    </a>
+  );
+}

--- a/libs/shared/ui/src/index.ts
+++ b/libs/shared/ui/src/index.ts
@@ -1,2 +1,3 @@
 export * from './button';
 export * from './loader';
+export * from './home-link';


### PR DESCRIPTION
## Summary
Adds a Home link/button to the joe-bot and todo-app headers so users can navigate back to the landing page.

## Changes
- **HomeLink component** in `@hello-ai/shared-ui` – links back to landing page (uses env vars for production, localhost ports for dev)
- **joe-bot** – Home button in header next to Clear
- **todo-app** – Home button in header
- **e2e tests** – Home link visibility tests for both apps
- **todo-app-e2e** – Fixed Playwright config to use port 3012 (matches todo-app dev server)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/navigation change plus E2E test/config updates; minimal impact beyond a new external link destination controlled by an env var.
> 
> **Overview**
> Adds a reusable `HomeLink` component to `@hello-ai/shared-ui` that routes to the landing page via `NEXT_PUBLIC_LANDING_PAGE_URL` (fallbacking to a hosted URL, and switching to `localhost:3011` when running locally).
> 
> Updates `joe-bot` and `todo-app` headers to include the new Home link, and adjusts E2E coverage to assert the updated page titles and that the Home link is visible/has an `href`. Also fixes `todo-app-e2e` Playwright config to use port `3012` to match the app’s dev server.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6459fe72b1971f595249a46174a7fc69fa5803c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->