### PR TITLE
chore: remove ci.yml from sharedGlobals to improve Nx Cloud cache hit rate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
-# CI workflow for lint, test, build, and e2e
 name: CI
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+# CI workflow for lint, test, build, and e2e
 name: CI
 
 env:

--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
       "!{projectRoot}/src/test-setup.[jt]s",
       "!{projectRoot}/test-setup.[jt]s"
     ],
-    "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
+    "sharedGlobals": []
   },
   "nxCloudId": "68cd99327c8b4045e0d56253",
   "plugins": [


### PR DESCRIPTION
Co-authored-by: Cursor <cursoragent@cursor.com>
