### PR TITLE
fix: harden landing URL parsing for Home link

### DIFF
--- a/libs/shared/ui/src/home-link.tsx
+++ b/libs/shared/ui/src/home-link.tsx
@@ -9,10 +9,25 @@ function isLocalHost(hostname: string) {
   return hostname === 'localhost' || hostname === '127.0.0.1';
 }
 
+function normalizeLandingUrl(candidate: string | undefined) {
+  const raw = candidate?.trim();
+  if (!raw) return FALLBACK_LANDING_URL;
+
+  try {
+    return new URL(raw).toString();
+  } catch {
+    // Support host-only values from env vars like "example.com".
+    try {
+      return new URL(`https://${raw}`).toString();
+    } catch {
+      return FALLBACK_LANDING_URL;
+    }
+  }
+}
+
 export function HomeLink() {
   const [url, setUrl] = useState(
-    () =>
-      process.env.NEXT_PUBLIC_LANDING_PAGE_URL || FALLBACK_LANDING_URL
+    () => normalizeLandingUrl(process.env.NEXT_PUBLIC_LANDING_PAGE_URL)
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- validate and normalize `NEXT_PUBLIC_LANDING_PAGE_URL` before rendering the Home link URL
- support host-only env values by coercing to `https://<host>`
- fall back to the default landing URL when env input is empty or malformed to prevent runtime URL pattern errors in production

## Test plan
- [x] run `pnpm nx build todo-app --skip-nx-cache`
- [x] verify no lints in `libs/shared/ui/src/home-link.tsx`
- [ ] deploy and confirm Home link navigation works with valid, host-only, and malformed `NEXT_PUBLIC_LANDING_PAGE_URL` values

Made with [Cursor](https://cursor.com)