### PR TITLE
fix: harden prod URL parsing and joe-bot chat route

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Deploy each app as a separate Vercel project. Set **Root Directory** to the app 
 |---------|----------|---------|
 | **landing-page** | `NEXT_PUBLIC_JOE_BOT_URL` | Joe-bot URL (fallback: joe-bot.vercel.app) |
 | **landing-page** | `NEXT_PUBLIC_TODO_APP_URL` | Todo app URL (fallback: joes-todo-app.vercel.app) |
+| **joe-bot** | `OPENAI_API_KEY` | Required server key for `/api/chat` |
 | **joe-bot** | `NEXT_PUBLIC_LANDING_PAGE_URL` | Home link target (fixes 404) |
 | **todo-app** | `NEXT_PUBLIC_LANDING_PAGE_URL` | Home link target (fixes 404) |
 

--- a/apps/joe-bot/package.json
+++ b/apps/joe-bot/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "next": "~16.1.6",
+    "openai": "^6.18.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "@hello-ai/shared-ui": "workspace:*",

--- a/apps/joe-bot/src/app/api/chat/route.ts
+++ b/apps/joe-bot/src/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
 
 type ChatRequest = { message?: string };
 
@@ -69,7 +70,7 @@ export async function POST(req: Request) {
       return new Response(
         JSON.stringify({
           error:
-            'OPENAI_API_KEY not found. Ensure .env.local is configured (repo root or apps/joe-bot) and restart dev server.',
+            'OPENAI_API_KEY not found. Configure it for this deployment (e.g. Vercel project env) and redeploy.',
         }),
         { status: 500, headers: { 'Content-Type': 'application/json' } },
       );

--- a/apps/landing-page/src/app/project-links.tsx
+++ b/apps/landing-page/src/app/project-links.tsx
@@ -18,16 +18,33 @@ function isLocalHost(hostname: string) {
   return hostname === 'localhost' || hostname === '127.0.0.1';
 }
 
+function normalizeExternalUrl(candidate: string | undefined, fallback: string) {
+  const raw = candidate?.trim();
+  if (!raw) return fallback;
+  if (raw.startsWith('/')) return fallback;
+
+  try {
+    const parsed = new URL(raw);
+    if (!parsed.hostname) return fallback;
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return fallback;
+    return parsed.toString();
+  } catch {
+    try {
+      const parsed = new URL(`https://${raw}`);
+      if (!parsed.hostname) return fallback;
+      return parsed.toString();
+    } catch {
+      return fallback;
+    }
+  }
+}
+
 export function ProjectLinks() {
   const [joeBotUrl, setJoeBotUrl] = useState(
-    () =>
-      process.env.NEXT_PUBLIC_JOE_BOT_URL ||
-      FALLBACK_JOE_BOT_URL
+    () => normalizeExternalUrl(process.env.NEXT_PUBLIC_JOE_BOT_URL, FALLBACK_JOE_BOT_URL)
   );
   const [todoAppUrl, setTodoAppUrl] = useState(
-    () =>
-      process.env.NEXT_PUBLIC_TODO_APP_URL ||
-      FALLBACK_TODO_APP_URL
+    () => normalizeExternalUrl(process.env.NEXT_PUBLIC_TODO_APP_URL, FALLBACK_TODO_APP_URL)
   );
 
   useEffect(() => {

--- a/libs/shared/ui/src/home-link.tsx
+++ b/libs/shared/ui/src/home-link.tsx
@@ -9,10 +9,25 @@ function isLocalHost(hostname: string) {
   return hostname === 'localhost' || hostname === '127.0.0.1';
 }
 
+function normalizeLandingUrl(candidate: string | undefined) {
+  const raw = candidate?.trim();
+  if (!raw) return FALLBACK_LANDING_URL;
+
+  try {
+    return new URL(raw).toString();
+  } catch {
+    // Support host-only values from env vars like "example.com".
+    try {
+      return new URL(`https://${raw}`).toString();
+    } catch {
+      return FALLBACK_LANDING_URL;
+    }
+  }
+}
+
 export function HomeLink() {
   const [url, setUrl] = useState(
-    () =>
-      process.env.NEXT_PUBLIC_LANDING_PAGE_URL || FALLBACK_LANDING_URL
+    () => normalizeLandingUrl(process.env.NEXT_PUBLIC_LANDING_PAGE_URL)
   );
 
   useEffect(() => {

--- a/libs/shared/ui/src/home-link.tsx
+++ b/libs/shared/ui/src/home-link.tsx
@@ -12,13 +12,21 @@ function isLocalHost(hostname: string) {
 function normalizeLandingUrl(candidate: string | undefined) {
   const raw = candidate?.trim();
   if (!raw) return FALLBACK_LANDING_URL;
+  if (raw.startsWith('/')) return FALLBACK_LANDING_URL;
 
   try {
-    return new URL(raw).toString();
+    const parsed = new URL(raw);
+    if (!parsed.hostname) return FALLBACK_LANDING_URL;
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return FALLBACK_LANDING_URL;
+    }
+    return parsed.toString();
   } catch {
     // Support host-only values from env vars like "example.com".
     try {
-      return new URL(`https://${raw}`).toString();
+      const parsed = new URL(`https://${raw}`);
+      if (!parsed.hostname) return FALLBACK_LANDING_URL;
+      return parsed.toString();
     } catch {
       return FALLBACK_LANDING_URL;
     }
@@ -41,7 +49,7 @@ export function HomeLink() {
 
   return (
     <a
-      href={url}
+      href={url.startsWith('http://') || url.startsWith('https://') ? url : FALLBACK_LANDING_URL}
       className="inline-flex cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-500 hover:bg-zinc-800 hover:text-zinc-100 active:scale-[0.98] transition-all duration-150"
     >
       <span aria-hidden>⌂</span>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       next:
         specifier: ~16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
+      openai:
+        specifier: ^6.18.0
+        version: 6.18.0(ws@8.19.0)(zod@4.3.6)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -205,6 +208,8 @@ importers:
         specifier: ^4.1.18
         version: 4.1.18
 
+  apps/landing-page-e2e: {}
+
   apps/todo-app:
     dependencies:
       '@hello-ai/shared-design':
@@ -231,8 +236,6 @@ importers:
         version: 4.1.18
 
   apps/todo-app-e2e: {}
-
-  joe-bot-e2e: {}
 
   libs/shared/design:
     dependencies:
@@ -15175,6 +15178,11 @@ snapshots:
   openai@6.18.0(ws@8.18.0)(zod@4.3.6):
     optionalDependencies:
       ws: 8.18.0
+      zod: 4.3.6
+
+  openai@6.18.0(ws@8.19.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.19.0
       zod: 4.3.6
 
   opener@1.5.2: {}


### PR DESCRIPTION
## Summary
- harden shared and landing-page external link URL normalization to prevent runtime browser pattern errors from malformed env values
- improve joe-bot `/api/chat` production resilience with explicit `openai` dependency and `maxDuration = 30`
- document `OPENAI_API_KEY` requirement for joe-bot deployments

## Test plan
- [x] `pnpm nx build todo-app --skip-nx-cache`
- [x] `pnpm nx build joe-bot --skip-nx-cache`
- [x] confirm no lint errors in touched files
- [ ] verify in Vercel that `NEXT_PUBLIC_LANDING_PAGE_URL` and `OPENAI_API_KEY` are set correctly and redeploy

Made with [Cursor](https://cursor.com)