### PR TITLE
Page background sections

### DIFF
--- a/apps/joe-bot/src/app/global.css
+++ b/apps/joe-bot/src/app/global.css
@@ -6,11 +6,15 @@
 /* ---- Base document styles ---- */
 html,
 body {
-  height: 100%;
+  width: 100%;
+  max-width: 100%;
+  min-height: 100%;
+  margin: 0;
+  overflow-x: hidden;
+  background-color: #09090b;
 }
 
 body {
-  margin: 0;
   font-family:
     ui-sans-serif,
     system-ui,
@@ -22,7 +26,6 @@ body {
     Arial,
     'Apple Color Emoji',
     'Segoe UI Emoji';
-  background-color: #0b1020;
   color: #e5e7eb;
   line-height: 1.5;
 }
@@ -82,10 +85,4 @@ pre {
   padding: 0.75rem 1rem;
   border-radius: 0.5rem;
   overflow-x: auto;
-}
-html,
-body {
-  width: 100%;
-  max-width: 100%;
-  overflow-x: hidden;
 }

--- a/apps/landing-page/src/app/global.css
+++ b/apps/landing-page/src/app/global.css
@@ -1,1 +1,8 @@
 @import "tailwindcss";
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  background-color: #09090b;
+}

--- a/apps/todo-app/src/app/global.css
+++ b/apps/todo-app/src/app/global.css
@@ -2,3 +2,10 @@
 
 /* Ensure shared-ui component classes are included */
 @source "../../../../libs/shared/ui/src/**/*.{ts,tsx}";
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  background-color: #09090b;
+}


### PR DESCRIPTION
Align mobile page-edge background with the app's dark theme by setting `html, body` background to black and removing default margins.

The white strips were visible on mobile devices at the very top and bottom of the `landing-page`, `Joe-bot`, and `todo-app` due to default browser margins or viewport overscroll/safe-area edges revealing the underlying white background. This fix ensures a consistent dark theme across the entire viewport.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e62fa8a3-055b-4a3e-b42a-2bada2d279aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e62fa8a3-055b-4a3e-b42a-2bada2d279aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

