### PR TITLE
CI setup evaluation and improvement plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 # data-persistence build artifacts
 libs/data-persistence/dist
 libs/data-persistence/data
+libs/data-persistence/core/data
 .cursor/
 .github/instructions/nx.instructions.md
 

--- a/apps/joe-bot/package.json
+++ b/apps/joe-bot/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@hello-ai/data-persistence": "workspace:*",
+    "@hello-ai/data-persistence-chat": "workspace:*",
+    "@hello-ai/data-persistence-session": "workspace:*",
     "@hello-ai/shared-design": "workspace:*",
     "@hello-ai/shared-ui": "workspace:*",
     "@libsql/client": "^0.14.0",

--- a/apps/joe-bot/project.json
+++ b/apps/joe-bot/project.json
@@ -1,5 +1,14 @@
 {
   "targets": {
+    "build": {
+      "inputs": [
+        "production",
+        "^production",
+        {
+          "externalDependencies": ["next"]
+        }
+      ]
+    },
     "dev": {
       "options": {
         "command": "next dev -p 3010"

--- a/apps/joe-bot/src/app/api/chat/route.ts
+++ b/apps/joe-bot/src/app/api/chat/route.ts
@@ -1,11 +1,13 @@
 import OpenAI from 'openai';
 import {
-  getOrCreateSessionId,
-  sessionCookieHeader,
   ensureChatMigrations,
   getChatMessages,
   insertChatMessage,
-} from '@hello-ai/data-persistence';
+} from '@hello-ai/data-persistence-chat';
+import {
+  getOrCreateSessionId,
+  sessionCookieHeader,
+} from '@hello-ai/data-persistence-session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/apps/joe-bot/src/app/api/messages/route.ts
+++ b/apps/joe-bot/src/app/api/messages/route.ts
@@ -1,11 +1,13 @@
 import {
-  getOrCreateSessionId,
-  sessionCookieHeader,
   ensureChatMigrations,
   getChatMessages,
   deleteChatMessagesForSession,
   deleteOldChatMessages,
-} from '@hello-ai/data-persistence';
+} from '@hello-ai/data-persistence-chat';
+import {
+  getOrCreateSessionId,
+  sessionCookieHeader,
+} from '@hello-ai/data-persistence-session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/apps/joe-bot/tsconfig.json
+++ b/apps/joe-bot/tsconfig.json
@@ -11,8 +11,8 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "plugins": [{"name": "next"}],
-    "paths": {"@/*": ["./src/*"]},
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] },
     "types": ["jest", "node"],
     "outDir": "dist",
     "rootDir": "src",
@@ -27,6 +27,30 @@
     "../../dist/apps/joe-bot/.next/types/**/*.ts",
     "next-env.d.ts"
   ],
-  "exclude": ["out-tsc", "dist", "node_modules", "jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts", ".next", "eslint.config.js", "eslint.config.cjs", "eslint.config.mjs"],
-  "references": []
+  "exclude": [
+    "out-tsc",
+    "dist",
+    "node_modules",
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    ".next",
+    "eslint.config.js",
+    "eslint.config.cjs",
+    "eslint.config.mjs"
+  ],
+  "references": [
+    {
+      "path": "../../libs/shared/ui"
+    },
+    {
+      "path": "../../libs/shared/design"
+    },
+    {
+      "path": "../../libs/data-persistence/session"
+    },
+    {
+      "path": "../../libs/data-persistence/chat"
+    }
+  ]
 }

--- a/apps/landing-page/project.json
+++ b/apps/landing-page/project.json
@@ -1,5 +1,14 @@
 {
   "targets": {
+    "build": {
+      "inputs": [
+        "production",
+        "^production",
+        {
+          "externalDependencies": ["next"]
+        }
+      ]
+    },
     "dev": {
       "options": {
         "command": "next dev -p 3011"

--- a/apps/landing-page/tsconfig.json
+++ b/apps/landing-page/tsconfig.json
@@ -34,7 +34,7 @@
   ],
   "references": [
     {
-      "path": "../../shared"
+      "path": "../../libs/shared/design"
     }
   ],
   "exclude": [

--- a/apps/todo-app/package.json
+++ b/apps/todo-app/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@hello-ai/data-persistence": "workspace:*",
+    "@hello-ai/data-persistence-session": "workspace:*",
+    "@hello-ai/data-persistence-todo": "workspace:*",
     "@hello-ai/shared-design": "workspace:*",
     "@hello-ai/shared-ui": "workspace:*",
     "@hello-ai/todo-data-access": "workspace:*",

--- a/apps/todo-app/project.json
+++ b/apps/todo-app/project.json
@@ -1,5 +1,14 @@
 {
   "targets": {
+    "build": {
+      "inputs": [
+        "production",
+        "^production",
+        {
+          "externalDependencies": ["next"]
+        }
+      ]
+    },
     "dev": {
       "options": {
         "command": "next dev -p 3012"

--- a/apps/todo-app/src/app/api/todos/[id]/route.ts
+++ b/apps/todo-app/src/app/api/todos/[id]/route.ts
@@ -1,11 +1,13 @@
 import {
-  getOrCreateSessionId,
-  sessionCookieHeader,
   ensureTodoMigrations,
   getTodoById,
   updateTodo,
   deleteTodo,
-} from '@hello-ai/data-persistence';
+} from '@hello-ai/data-persistence-todo';
+import {
+  getOrCreateSessionId,
+  sessionCookieHeader,
+} from '@hello-ai/data-persistence-session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/apps/todo-app/src/app/api/todos/route.ts
+++ b/apps/todo-app/src/app/api/todos/route.ts
@@ -1,11 +1,13 @@
 import {
-  getOrCreateSessionId,
-  sessionCookieHeader,
   ensureTodoMigrations,
   getTodos,
   createTodo,
   deleteOldCompletedTodos,
-} from '@hello-ai/data-persistence';
+} from '@hello-ai/data-persistence-todo';
+import {
+  getOrCreateSessionId,
+  sessionCookieHeader,
+} from '@hello-ai/data-persistence-session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/apps/todo-app/tsconfig.json
+++ b/apps/todo-app/tsconfig.json
@@ -34,7 +34,19 @@
   ],
   "references": [
     {
-      "path": "../../shared"
+      "path": "../../libs/todo/data-access"
+    },
+    {
+      "path": "../../libs/shared/ui"
+    },
+    {
+      "path": "../../libs/shared/design"
+    },
+    {
+      "path": "../../libs/data-persistence/todo"
+    },
+    {
+      "path": "../../libs/data-persistence/session"
     }
   ],
   "exclude": [

--- a/libs/data-persistence/chat/package.json
+++ b/libs/data-persistence/chat/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hello-ai/data-persistence",
+  "name": "@hello-ai/data-persistence-chat",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -16,13 +16,7 @@
     }
   },
   "dependencies": {
-    "@hello-ai/data-persistence-chat": "workspace:*",
     "@hello-ai/data-persistence-core": "workspace:*",
-    "@hello-ai/data-persistence-session": "workspace:*",
-    "@hello-ai/data-persistence-todo": "workspace:*",
     "tslib": "^2.3.0"
-  },
-  "devDependencies": {
-    "drizzle-kit": "^0.28.0"
   }
 }

--- a/libs/data-persistence/chat/src/chat-api.ts
+++ b/libs/data-persistence/chat/src/chat-api.ts
@@ -1,0 +1,72 @@
+/**
+ * Chat API - abstracts over Drizzle (local) vs raw Turso HTTP (Vercel).
+ * Use this in routes instead of db directly when on Vercel.
+ */
+
+import {
+  asc,
+  chatMessages,
+  db,
+  drizzleDeleteOldChatMessages,
+  ensureMigrations,
+  eq,
+  tursoDeleteChatMessages,
+  tursoDeleteOldChatMessages,
+  tursoEnsureMigrations,
+  tursoGetChatMessages,
+  tursoInsertChatMessage,
+  useTursoHttp,
+} from '@hello-ai/data-persistence-core';
+
+export type ChatMessage = { id: string; role: string; content: string; createdAt: number };
+
+export async function getChatMessages(sessionId: string): Promise<ChatMessage[]> {
+  if (useTursoHttp()) {
+    const rows = await tursoGetChatMessages(sessionId);
+    return rows.map((r) => ({
+      id: r.id,
+      role: r.role,
+      content: r.content,
+      createdAt: r.created_at,
+    }));
+  }
+  const rows = await db.select().from(chatMessages).where(eq(chatMessages.sessionId, sessionId)).orderBy(asc(chatMessages.createdAt));
+  return rows.map((r) => ({ id: r.id, role: r.role, content: r.content, createdAt: r.createdAt }));
+}
+
+export async function insertChatMessage(id: string, sessionId: string, role: string, content: string, createdAt: number): Promise<void> {
+  if (useTursoHttp()) {
+    const result = await tursoInsertChatMessage(id, sessionId, role, content, createdAt);
+    if (!result.ok) {
+      const msg = result.error ?? 'Unknown Turso error';
+      console.error('[data-persistence] insert failed', { error: msg });
+      throw new Error(`Failed to insert chat message: ${msg}`);
+    }
+    return;
+  }
+  await db.insert(chatMessages).values({ id, sessionId, role, content, createdAt });
+}
+
+export async function deleteChatMessagesForSession(sessionId: string): Promise<void> {
+  if (useTursoHttp()) {
+    await tursoDeleteChatMessages(sessionId);
+    return;
+  }
+  await db.delete(chatMessages).where(eq(chatMessages.sessionId, sessionId));
+}
+
+export async function ensureChatMigrations(): Promise<void> {
+  if (useTursoHttp()) {
+    await tursoEnsureMigrations();
+    return;
+  }
+  await ensureMigrations();
+}
+
+export async function deleteOldChatMessages(): Promise<void> {
+  if (useTursoHttp()) {
+    await tursoDeleteOldChatMessages();
+    return;
+  }
+  await drizzleDeleteOldChatMessages();
+}

--- a/libs/data-persistence/chat/src/index.ts
+++ b/libs/data-persistence/chat/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  getChatMessages,
+  insertChatMessage,
+  deleteChatMessagesForSession,
+  ensureChatMigrations,
+  deleteOldChatMessages,
+} from './chat-api';
+export type { ChatMessage } from './chat-api';

--- a/libs/data-persistence/chat/tsconfig.json
+++ b/libs/data-persistence/chat/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/data-persistence/chat/tsconfig.lib.json
+++ b/libs/data-persistence/chat/tsconfig.lib.json
@@ -13,5 +13,9 @@
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/*.spec.ts"],
-  "references": []
+  "references": [
+    {
+      "path": "../core/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/data-persistence/chat/tsconfig.lib.json
+++ b/libs/data-persistence/chat/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },
-  "include": ["src/index.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["**/*.spec.ts"],
   "references": []
 }

--- a/libs/data-persistence/core/package.json
+++ b/libs/data-persistence/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hello-ai/data-persistence",
+  "name": "@hello-ai/data-persistence-core",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -16,13 +16,8 @@
     }
   },
   "dependencies": {
-    "@hello-ai/data-persistence-chat": "workspace:*",
-    "@hello-ai/data-persistence-core": "workspace:*",
-    "@hello-ai/data-persistence-session": "workspace:*",
-    "@hello-ai/data-persistence-todo": "workspace:*",
+    "@libsql/client": "^0.14.0",
+    "drizzle-orm": "^0.36.0",
     "tslib": "^2.3.0"
-  },
-  "devDependencies": {
-    "drizzle-kit": "^0.28.0"
   }
 }

--- a/libs/data-persistence/core/src/db.ts
+++ b/libs/data-persistence/core/src/db.ts
@@ -1,0 +1,121 @@
+import { drizzle } from 'drizzle-orm/libsql';
+import { sql } from 'drizzle-orm';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as schema from './schema';
+
+function getLocalDbPath(): string {
+  try {
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    const dataDir = path.join(dir, '..', 'data');
+    fs.mkdirSync(dataDir, { recursive: true });
+    return `file:${path.join(dataDir, 'local.db')}`;
+  } catch {
+    return 'file:./data/local.db';
+  }
+}
+
+// Normalize env vars - Vercel often adds newlines when pasting; avoid surrounding quotes
+let url = (process.env.TURSO_DATABASE_URL ?? getLocalDbPath()).trim().replace(/^["']|["']$/g, '');
+const rawToken = process.env.TURSO_AUTH_TOKEN?.trim().replace(/^["']|["']$/g, '') ?? '';
+const authToken = rawToken || undefined;
+
+// Only pass authToken for remote URLs - file: URLs ignore it and can cause 400
+const isRemote = url.startsWith('libsql://') || url.startsWith('https://');
+
+// On Vercel: use https:// instead of libsql:// to force HTTP (avoid WebSocket 400 in serverless)
+if (process.env.VERCEL === '1' && url.startsWith('libsql://')) {
+  url = url.replace(/^libsql:\/\//, 'https://');
+}
+
+// Use @libsql/client/web on Vercel (fetch-only); else default client for file: support
+const isVercel = process.env.VERCEL === '1';
+const useWebClient = isVercel && isRemote;
+
+const { createClient } = useWebClient
+  ? await import('@libsql/client/web')
+  : await import('@libsql/client');
+
+const client = createClient({
+  url,
+  ...(isRemote && authToken && { authToken }),
+});
+
+export const db = drizzle(client, { schema });
+
+// Log config at load (helps debug Turso 400 - redacts secrets)
+if (process.env.VERCEL === '1' && isRemote) {
+  const hasToken = Boolean(authToken);
+  const tokenLength = authToken?.length ?? 0;
+  console.info(
+    `[data-persistence] url=${url.slice(0, 40)}... auth=${hasToken} tokenLen=${tokenLength}`
+  );
+}
+
+// Auto-run migrations on first import
+let migrationPromise: Promise<void> | null = null;
+
+async function rawTursoExecute(sqlStatement: string): Promise<{ ok: boolean; status?: number; body?: string }> {
+  if (!isRemote || !authToken) return { ok: false };
+  const baseUrl = url.startsWith('https://') ? url : `https://${url.replace(/^libsql:\/\//, '')}`;
+  const pipelineUrl = `${baseUrl}/v2/pipeline`;
+  try {
+    const res = await fetch(pipelineUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        requests: [{ type: 'execute' as const, stmt: { sql: sqlStatement } }, { type: 'close' as const }],
+      }),
+    });
+    const body = await res.text();
+    if (!res.ok) {
+      console.error('[data-persistence] raw Turso request failed', { sql: sqlStatement.slice(0, 50), status: res.status, body: body.slice(0, 300) });
+      return { ok: false, status: res.status, body };
+    }
+    return { ok: true };
+  } catch (e) {
+    console.error('[data-persistence] raw Turso error', e);
+    return { ok: false, body: String(e) };
+  }
+}
+
+const MIGRATION_SQL = [
+  `CREATE TABLE IF NOT EXISTS chat_messages (id text PRIMARY KEY NOT NULL, session_id text NOT NULL, role text NOT NULL, content text NOT NULL, created_at integer NOT NULL)`,
+  `CREATE TABLE IF NOT EXISTS todos (id text PRIMARY KEY NOT NULL, session_id text NOT NULL, text text NOT NULL, completed integer DEFAULT 0 NOT NULL, completed_at integer, created_at integer NOT NULL)`,
+];
+
+export async function ensureMigrations(): Promise<void> {
+  if (!migrationPromise) {
+    migrationPromise = (async () => {
+      // Use raw HTTP for Turso (avoids libSQL client 400 in serverless)
+      const hasUrl = Boolean(process.env.TURSO_DATABASE_URL);
+      const hasToken = Boolean(process.env.TURSO_AUTH_TOKEN);
+      if (process.env.VERCEL === '1') {
+        console.info('[data-persistence] ensureMigrations', { isRemote, hasUrl, hasToken, authTokenLen: authToken?.length ?? 0 });
+      }
+      if (isRemote && authToken) {
+        for (const stmt of MIGRATION_SQL) {
+          const result = await rawTursoExecute(stmt);
+          if (!result.ok) {
+            console.warn('[data-persistence] Migration failed:', result.body ?? result.status);
+          }
+        }
+        return;
+      }
+      if (isRemote && !authToken) {
+        throw new Error('TURSO_AUTH_TOKEN is required when using TURSO_DATABASE_URL. Add it to your Vercel project env vars.');
+      }
+      try {
+        await db.run(sql`CREATE TABLE IF NOT EXISTS chat_messages (id text PRIMARY KEY NOT NULL, session_id text NOT NULL, role text NOT NULL, content text NOT NULL, created_at integer NOT NULL)`);
+        await db.run(sql`CREATE TABLE IF NOT EXISTS todos (id text PRIMARY KEY NOT NULL, session_id text NOT NULL, text text NOT NULL, completed integer DEFAULT 0 NOT NULL, completed_at integer, created_at integer NOT NULL)`);
+      } catch (error) {
+        console.warn('Migration warning (may be already applied):', error);
+      }
+    })();
+  }
+  return migrationPromise;
+}

--- a/libs/data-persistence/core/src/index.ts
+++ b/libs/data-persistence/core/src/index.ts
@@ -1,0 +1,19 @@
+export { db, ensureMigrations } from './db';
+export { chatMessages, todos } from './schema';
+export { eq, asc } from 'drizzle-orm';
+export type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
+export {
+  useTursoHttp,
+  tursoGetChatMessages,
+  tursoInsertChatMessage,
+  tursoDeleteChatMessages,
+  tursoDeleteOldChatMessages,
+  tursoEnsureMigrations,
+  tursoGetTodos,
+  tursoGetTodoById,
+  tursoInsertTodo,
+  tursoUpdateTodo,
+  tursoDeleteTodo,
+  tursoDeleteOldCompletedTodos,
+} from './turso-http';
+export { drizzleDeleteOldChatMessages, drizzleDeleteOldCompletedTodos } from './retention';

--- a/libs/data-persistence/core/src/retention.ts
+++ b/libs/data-persistence/core/src/retention.ts
@@ -1,0 +1,27 @@
+import { and, eq, isNotNull, lt } from 'drizzle-orm';
+import { db } from './db';
+import { chatMessages, todos } from './schema';
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+export async function drizzleDeleteOldChatMessages(): Promise<number> {
+  const cutoff = Date.now() - NINETY_DAYS_MS;
+  const result = await db
+    .delete(chatMessages)
+    .where(lt(chatMessages.createdAt, cutoff));
+  return result.rowsAffected;
+}
+
+export async function drizzleDeleteOldCompletedTodos(): Promise<number> {
+  const cutoff = Date.now() - NINETY_DAYS_MS;
+  const result = await db
+    .delete(todos)
+    .where(
+      and(
+        eq(todos.completed, true),
+        isNotNull(todos.completedAt),
+        lt(todos.completedAt!, cutoff)
+      )
+    );
+  return result.rowsAffected;
+}

--- a/libs/data-persistence/core/src/schema.ts
+++ b/libs/data-persistence/core/src/schema.ts
@@ -1,0 +1,22 @@
+import {
+  integer,
+  sqliteTable,
+  text,
+} from 'drizzle-orm/sqlite-core';
+
+export const chatMessages = sqliteTable('chat_messages', {
+  id: text('id').primaryKey(),
+  sessionId: text('session_id').notNull(),
+  role: text('role').notNull(), // 'user' | 'assistant'
+  content: text('content').notNull(),
+  createdAt: integer('created_at', { mode: 'number' }).notNull(),
+});
+
+export const todos = sqliteTable('todos', {
+  id: text('id').primaryKey(),
+  sessionId: text('session_id').notNull(),
+  text: text('text').notNull(),
+  completed: integer('completed', { mode: 'boolean' }).notNull().default(false),
+  completedAt: integer('completed_at', { mode: 'number' }),
+  createdAt: integer('created_at', { mode: 'number' }).notNull(),
+});

--- a/libs/data-persistence/core/src/turso-http.ts
+++ b/libs/data-persistence/core/src/turso-http.ts
@@ -1,0 +1,174 @@
+/**
+ * Raw Turso HTTP client - bypasses @libsql/client to avoid 400 in Vercel serverless.
+ * Uses Turso's v2/pipeline API directly.
+ */
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+function getConfig() {
+  const url = (process.env.TURSO_DATABASE_URL ?? '').trim().replace(/^["']|["']$/g, '');
+  const authToken = (process.env.TURSO_AUTH_TOKEN ?? '').trim().replace(/^["']|["']$/g, '');
+  const isRemote = url.startsWith('libsql://') || url.startsWith('https://');
+  const baseUrl = url.startsWith('https://') ? url : url.startsWith('libsql://') ? url.replace(/^libsql:\/\//, 'https://') : '';
+  return { baseUrl, authToken, isRemote };
+}
+
+async function execute(sql: string, args?: Record<string, string | number | null>): Promise<{ rows: Array<Record<string, unknown>>; ok: boolean; error?: string }> {
+  const { baseUrl, authToken, isRemote } = getConfig();
+  if (!isRemote || !authToken || !baseUrl) {
+    return { rows: [], ok: false, error: 'Turso config missing' };
+  }
+  const pipelineUrl = `${baseUrl}/v2/pipeline`;
+  const stmt: { sql: string; named_args?: Array<{ name: string; value: { type: string; value: string } }> } = { sql };
+  if (args && Object.keys(args).length > 0) {
+    stmt.named_args = Object.entries(args).map(([name, val]) => {
+      if (val === null) return { name, value: { type: 'null' as const, value: '' } };
+      if (typeof val === 'number') return { name, value: { type: 'integer' as const, value: String(val) } };
+      return { name, value: { type: 'text' as const, value: String(val) } };
+    });
+  }
+  try {
+    const res = await fetch(pipelineUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        requests: [{ type: 'execute' as const, stmt }, { type: 'close' as const }],
+      }),
+    });
+    const body = await res.text();
+    if (!res.ok) {
+      return { rows: [], ok: false, error: `HTTP ${res.status}: ${body.slice(0, 200)}` };
+    }
+    const data = JSON.parse(body) as { results?: Array<{ type?: string; response?: { result?: { cols?: string[]; rows?: Array<{ value: unknown }[]> } } }> };
+    const result = data.results?.[0]?.response?.result;
+    if (!result?.rows) return { rows: [], ok: true };
+    const cols = (result.cols ?? []).map((c) => (typeof c === 'string' ? c : (c as { name?: string }).name ?? ''));
+    const rows = (result.rows ?? []).map((row) => {
+      const obj: Record<string, unknown> = {};
+      cols.forEach((colName, i) => {
+        const cell = row[i];
+        const val = cell && typeof cell === 'object' && 'value' in cell ? (cell as { value: unknown }).value : cell;
+        if (colName) obj[colName] = val;
+      });
+      return obj;
+    });
+    return { rows, ok: true };
+  } catch (e) {
+    return { rows: [], ok: false, error: String(e) };
+  }
+}
+
+export type ChatRow = { id: string; session_id: string; role: string; content: string; created_at: number };
+
+export async function tursoGetChatMessages(sessionId: string): Promise<ChatRow[]> {
+  const { rows } = await execute(
+    'SELECT id, session_id, role, content, created_at FROM chat_messages WHERE session_id = :sid ORDER BY created_at ASC',
+    { sid: sessionId }
+  );
+  return rows as ChatRow[];
+}
+
+export async function tursoInsertChatMessage(id: string, sessionId: string, role: string, content: string, createdAt: number): Promise<{ ok: boolean; error?: string }> {
+  return execute(
+    'INSERT INTO chat_messages (id, session_id, role, content, created_at) VALUES (:id, :sid, :role, :content, :ts)',
+    { id, sid: sessionId, role, content, ts: createdAt }
+  );
+}
+
+export async function tursoDeleteChatMessages(sessionId: string): Promise<boolean> {
+  const { ok } = await execute('DELETE FROM chat_messages WHERE session_id = :sid', { sid: sessionId });
+  return ok;
+}
+
+export async function tursoDeleteOldChatMessages(): Promise<boolean> {
+  const cutoff = Date.now() - NINETY_DAYS_MS;
+  const { ok } = await execute('DELETE FROM chat_messages WHERE created_at < :cutoff', { cutoff });
+  return ok;
+}
+
+export async function tursoEnsureMigrations(): Promise<void> {
+  const migrations = [
+    'CREATE TABLE IF NOT EXISTS chat_messages (id text PRIMARY KEY NOT NULL, session_id text NOT NULL, role text NOT NULL, content text NOT NULL, created_at integer NOT NULL)',
+    'CREATE TABLE IF NOT EXISTS todos (id text PRIMARY KEY NOT NULL, session_id text NOT NULL, text text NOT NULL, completed integer DEFAULT 0 NOT NULL, completed_at integer, created_at integer NOT NULL)',
+  ];
+  for (const sql of migrations) {
+    const r = await execute(sql);
+    if (!r.ok) console.error('[data-persistence] Migration failed:', r.error);
+  }
+}
+
+export type TodoRow = { id: string; session_id: string; text: string; completed: number; completed_at: number | null; created_at: number };
+
+export async function tursoGetTodos(sessionId: string): Promise<TodoRow[]> {
+  const { rows } = await execute(
+    'SELECT id, session_id, text, completed, completed_at, created_at FROM todos WHERE session_id = :sid ORDER BY created_at ASC',
+    { sid: sessionId }
+  );
+  return rows as TodoRow[];
+}
+
+export async function tursoGetTodoById(id: string): Promise<TodoRow | null> {
+  const { rows } = await execute('SELECT id, session_id, text, completed, completed_at, created_at FROM todos WHERE id = :id LIMIT 1', {
+    id,
+  });
+  return (rows[0] as TodoRow) ?? null;
+}
+
+export async function tursoInsertTodo(
+  id: string,
+  sessionId: string,
+  text: string,
+  completed: number,
+  createdAt: number
+): Promise<{ ok: boolean; error?: string }> {
+  return execute('INSERT INTO todos (id, session_id, text, completed, created_at) VALUES (:id, :sid, :text, :completed, :ts)', {
+    id,
+    sid: sessionId,
+    text,
+    completed,
+    ts: createdAt,
+  });
+}
+
+export async function tursoUpdateTodo(
+  id: string,
+  updates: { text?: string; completed?: number; completedAt?: number | null }
+): Promise<{ ok: boolean; error?: string }> {
+  const keys = Object.keys(updates);
+  if (keys.length === 0) return { ok: true };
+  const sets: string[] = [];
+  const args: Record<string, string | number | null> = { id };
+  if (updates.text !== undefined) {
+    sets.push('text = :text');
+    args.text = updates.text;
+  }
+  if (updates.completed !== undefined) {
+    sets.push('completed = :completed');
+    args.completed = updates.completed;
+  }
+  if (updates.completedAt !== undefined) {
+    sets.push('completed_at = :completedAt');
+    args.completedAt = updates.completedAt;
+  }
+  return execute(`UPDATE todos SET ${sets.join(', ')} WHERE id = :id`, args);
+}
+
+export async function tursoDeleteTodo(id: string): Promise<{ ok: boolean; error?: string }> {
+  return execute('DELETE FROM todos WHERE id = :id', { id });
+}
+
+export async function tursoDeleteOldCompletedTodos(): Promise<boolean> {
+  const cutoff = Date.now() - NINETY_DAYS_MS;
+  const { ok } = await execute('DELETE FROM todos WHERE completed = 1 AND completed_at IS NOT NULL AND completed_at < :cutoff', {
+    cutoff,
+  });
+  return ok;
+}
+
+export function useTursoHttp(): boolean {
+  const { baseUrl, authToken, isRemote } = getConfig();
+  return process.env.VERCEL === '1' && isRemote && !!authToken && !!baseUrl;
+}

--- a/libs/data-persistence/core/tsconfig.json
+++ b/libs/data-persistence/core/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/data-persistence/core/tsconfig.lib.json
+++ b/libs/data-persistence/core/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },
-  "include": ["src/index.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["**/*.spec.ts"],
   "references": []
 }

--- a/libs/data-persistence/session/package.json
+++ b/libs/data-persistence/session/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hello-ai/data-persistence",
+  "name": "@hello-ai/data-persistence-session",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -16,13 +16,7 @@
     }
   },
   "dependencies": {
-    "@hello-ai/data-persistence-chat": "workspace:*",
-    "@hello-ai/data-persistence-core": "workspace:*",
-    "@hello-ai/data-persistence-session": "workspace:*",
-    "@hello-ai/data-persistence-todo": "workspace:*",
+    "next": "~16.1.6",
     "tslib": "^2.3.0"
-  },
-  "devDependencies": {
-    "drizzle-kit": "^0.28.0"
   }
 }

--- a/libs/data-persistence/session/src/index.ts
+++ b/libs/data-persistence/session/src/index.ts
@@ -1,0 +1,1 @@
+export { getOrCreateSessionId, sessionCookieHeader } from './session';

--- a/libs/data-persistence/session/src/session.ts
+++ b/libs/data-persistence/session/src/session.ts
@@ -1,0 +1,23 @@
+import { cookies } from 'next/headers';
+
+const SESSION_COOKIE = '__hello_ai_session';
+const SESSION_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+function uuid(): string {
+  return crypto.randomUUID();
+}
+
+export async function getOrCreateSessionId(): Promise<string> {
+  const cookieStore = await cookies();
+  let sessionId = cookieStore.get(SESSION_COOKIE)?.value;
+
+  if (!sessionId) {
+    sessionId = uuid();
+  }
+
+  return sessionId;
+}
+
+export function sessionCookieHeader(sessionId: string): string {
+  return `${SESSION_COOKIE}=${sessionId}; Path=/; Max-Age=${SESSION_MAX_AGE}; HttpOnly; SameSite=Lax`;
+}

--- a/libs/data-persistence/session/tsconfig.json
+++ b/libs/data-persistence/session/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/data-persistence/session/tsconfig.lib.json
+++ b/libs/data-persistence/session/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },
-  "include": ["src/index.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["**/*.spec.ts"],
   "references": []
 }

--- a/libs/data-persistence/src/index.ts
+++ b/libs/data-persistence/src/index.ts
@@ -1,15 +1,20 @@
-export { db, ensureMigrations } from './db';
-export { chatMessages, todos } from './schema';
-export { eq, asc } from 'drizzle-orm';
-export type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
-export { getOrCreateSessionId, sessionCookieHeader } from './session';
+export {
+  db,
+  ensureMigrations,
+  chatMessages,
+  todos,
+  eq,
+  asc,
+} from '@hello-ai/data-persistence-core';
+export type { InferSelectModel, InferInsertModel } from '@hello-ai/data-persistence-core';
+export { getOrCreateSessionId, sessionCookieHeader } from '@hello-ai/data-persistence-session';
 export {
   getChatMessages,
   insertChatMessage,
   deleteChatMessagesForSession,
   ensureChatMigrations,
   deleteOldChatMessages,
-} from './chat-api';
+} from '@hello-ai/data-persistence-chat';
 export {
   getTodos,
   createTodo,
@@ -18,4 +23,4 @@ export {
   deleteTodo,
   ensureTodoMigrations,
   deleteOldCompletedTodos,
-} from './todo-api';
+} from '@hello-ai/data-persistence-todo';

--- a/libs/data-persistence/todo/package.json
+++ b/libs/data-persistence/todo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hello-ai/data-persistence",
+  "name": "@hello-ai/data-persistence-todo",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -16,13 +16,7 @@
     }
   },
   "dependencies": {
-    "@hello-ai/data-persistence-chat": "workspace:*",
     "@hello-ai/data-persistence-core": "workspace:*",
-    "@hello-ai/data-persistence-session": "workspace:*",
-    "@hello-ai/data-persistence-todo": "workspace:*",
     "tslib": "^2.3.0"
-  },
-  "devDependencies": {
-    "drizzle-kit": "^0.28.0"
   }
 }

--- a/libs/data-persistence/todo/src/index.ts
+++ b/libs/data-persistence/todo/src/index.ts
@@ -1,0 +1,10 @@
+export {
+  getTodos,
+  createTodo,
+  getTodoById,
+  updateTodo,
+  deleteTodo,
+  ensureTodoMigrations,
+  deleteOldCompletedTodos,
+} from './todo-api';
+export type { TodoItem } from './todo-api';

--- a/libs/data-persistence/todo/src/todo-api.ts
+++ b/libs/data-persistence/todo/src/todo-api.ts
@@ -1,0 +1,118 @@
+/**
+ * Todo API - abstracts over Drizzle (local) vs raw Turso HTTP (Vercel).
+ */
+
+import {
+  asc,
+  db,
+  drizzleDeleteOldCompletedTodos,
+  ensureMigrations,
+  eq,
+  todos,
+  tursoDeleteOldCompletedTodos,
+  tursoDeleteTodo,
+  tursoEnsureMigrations,
+  tursoGetTodoById,
+  tursoGetTodos,
+  tursoInsertTodo,
+  tursoUpdateTodo,
+  useTursoHttp,
+} from '@hello-ai/data-persistence-core';
+
+export type TodoItem = { id: string; text: string; completed: boolean; createdAt: number };
+
+export async function getTodos(sessionId: string): Promise<TodoItem[]> {
+  if (useTursoHttp()) {
+    const rows = await tursoGetTodos(sessionId);
+    return rows.map((r) => ({
+      id: r.id,
+      text: r.text,
+      completed: Boolean(r.completed),
+      createdAt: r.created_at,
+    }));
+  }
+  const rows = await db.select().from(todos).where(eq(todos.sessionId, sessionId)).orderBy(asc(todos.createdAt));
+  return rows.map((r) => ({ id: r.id, text: r.text, completed: r.completed, createdAt: r.createdAt }));
+}
+
+export async function createTodo(
+  id: string,
+  sessionId: string,
+  text: string,
+  createdAt: number
+): Promise<TodoItem> {
+  if (useTursoHttp()) {
+    const result = await tursoInsertTodo(id, sessionId, text, 0, createdAt);
+    if (!result.ok) throw new Error(result.error ?? 'Failed to create todo');
+    return { id, text, completed: false, createdAt };
+  }
+  await db.insert(todos).values({ id, sessionId, text, completed: false, createdAt });
+  return { id, text, completed: false, createdAt };
+}
+
+export async function getTodoById(id: string): Promise<{ id: string; text: string; completed: boolean; createdAt: number; sessionId: string } | null> {
+  if (useTursoHttp()) {
+    const row = await tursoGetTodoById(id);
+    if (!row) return null;
+    return {
+      id: row.id,
+      text: row.text,
+      completed: Boolean(row.completed),
+      createdAt: row.created_at,
+      sessionId: row.session_id,
+    };
+  }
+  const rows = await db.select().from(todos).where(eq(todos.id, id)).limit(1);
+  const r = rows[0];
+  if (!r) return null;
+  return { id: r.id, text: r.text, completed: r.completed, createdAt: r.createdAt, sessionId: r.sessionId };
+}
+
+export async function updateTodo(
+  id: string,
+  updates: { text?: string; completed?: boolean; completedAt?: number | null }
+): Promise<TodoItem> {
+  if (useTursoHttp()) {
+    const dbUpdates: { text?: string; completed?: number; completedAt?: number | null } = {};
+    if (updates.text !== undefined) dbUpdates.text = updates.text;
+    if (updates.completed !== undefined) dbUpdates.completed = updates.completed ? 1 : 0;
+    if (updates.completedAt !== undefined) dbUpdates.completedAt = updates.completedAt;
+    const result = await tursoUpdateTodo(id, dbUpdates);
+    if (!result.ok) throw new Error(result.error ?? 'Failed to update todo');
+    const row = await tursoGetTodoById(id);
+    if (!row) throw new Error('Todo not found after update');
+    return { id: row.id, text: row.text, completed: Boolean(row.completed), createdAt: row.created_at };
+  }
+  const dbUpdates: Partial<{ text: string; completed: boolean; completedAt: number | null }> = {};
+  if (updates.text !== undefined) dbUpdates.text = updates.text;
+  if (updates.completed !== undefined) dbUpdates.completed = updates.completed;
+  if (updates.completedAt !== undefined) dbUpdates.completedAt = updates.completedAt;
+  const [updated] = await db.update(todos).set(dbUpdates).where(eq(todos.id, id)).returning();
+  if (!updated) throw new Error('Todo not found');
+  return { id: updated.id, text: updated.text, completed: updated.completed, createdAt: updated.createdAt };
+}
+
+export async function deleteTodo(id: string): Promise<void> {
+  if (useTursoHttp()) {
+    const result = await tursoDeleteTodo(id);
+    if (!result.ok) throw new Error(result.error ?? 'Failed to delete todo');
+    return;
+  }
+  await db.delete(todos).where(eq(todos.id, id));
+}
+
+export async function ensureTodoMigrations(): Promise<void> {
+  if (useTursoHttp()) {
+    await tursoEnsureMigrations();
+    return;
+  }
+  await ensureMigrations();
+}
+
+export async function deleteOldCompletedTodos(): Promise<void> {
+  if (useTursoHttp()) {
+    await tursoDeleteOldCompletedTodos();
+    return;
+  }
+  await drizzleDeleteOldCompletedTodos();
+}

--- a/libs/data-persistence/todo/tsconfig.json
+++ b/libs/data-persistence/todo/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/data-persistence/todo/tsconfig.lib.json
+++ b/libs/data-persistence/todo/tsconfig.lib.json
@@ -13,5 +13,9 @@
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/*.spec.ts"],
-  "references": []
+  "references": [
+    {
+      "path": "../core/tsconfig.lib.json"
+    }
+  ]
 }

--- a/libs/data-persistence/todo/tsconfig.lib.json
+++ b/libs/data-persistence/todo/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },
-  "include": ["src/index.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["**/*.spec.ts"],
   "references": []
 }

--- a/libs/data-persistence/tsconfig.lib.json
+++ b/libs/data-persistence/tsconfig.lib.json
@@ -13,5 +13,18 @@
   },
   "include": ["src/index.ts"],
   "exclude": ["**/*.spec.ts"],
-  "references": []
+  "references": [
+    {
+      "path": "todo/tsconfig.lib.json"
+    },
+    {
+      "path": "session/tsconfig.lib.json"
+    },
+    {
+      "path": "core/tsconfig.lib.json"
+    },
+    {
+      "path": "chat/tsconfig.lib.json"
+    }
+  ]
 }

--- a/nx.json
+++ b/nx.json
@@ -61,8 +61,18 @@
     }
   ],
   "targetDefaults": {
-    "test": {
-      "dependsOn": ["^build"]
+    "lint": {
+      "inputs": [
+        "default",
+        "{workspaceRoot}/eslint.config.mjs",
+        "{projectRoot}/eslint.config.js",
+        "{projectRoot}/eslint.config.cjs",
+        "{projectRoot}/eslint.config.mjs",
+        "{workspaceRoot}/tools/eslint-rules/**/*",
+        {
+          "externalDependencies": ["eslint"]
+        }
+      ]
     }
   },
   "generators": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,12 @@ importers:
 
   apps/joe-bot:
     dependencies:
-      '@hello-ai/data-persistence':
+      '@hello-ai/data-persistence-chat':
         specifier: workspace:*
-        version: link:../../libs/data-persistence
+        version: link:../../libs/data-persistence/chat
+      '@hello-ai/data-persistence-session':
+        specifier: workspace:*
+        version: link:../../libs/data-persistence/session
       '@hello-ai/shared-design':
         specifier: workspace:*
         version: link:../../libs/shared/design
@@ -221,9 +224,12 @@ importers:
 
   apps/todo-app:
     dependencies:
-      '@hello-ai/data-persistence':
+      '@hello-ai/data-persistence-session':
         specifier: workspace:*
-        version: link:../../libs/data-persistence
+        version: link:../../libs/data-persistence/session
+      '@hello-ai/data-persistence-todo':
+        specifier: workspace:*
+        version: link:../../libs/data-persistence/todo
       '@hello-ai/shared-design':
         specifier: workspace:*
         version: link:../../libs/shared/design
@@ -257,6 +263,37 @@ importers:
 
   libs/data-persistence:
     dependencies:
+      '@hello-ai/data-persistence-chat':
+        specifier: workspace:*
+        version: link:chat
+      '@hello-ai/data-persistence-core':
+        specifier: workspace:*
+        version: link:core
+      '@hello-ai/data-persistence-session':
+        specifier: workspace:*
+        version: link:session
+      '@hello-ai/data-persistence-todo':
+        specifier: workspace:*
+        version: link:todo
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+    devDependencies:
+      drizzle-kit:
+        specifier: ^0.28.0
+        version: 0.28.1
+
+  libs/data-persistence/chat:
+    dependencies:
+      '@hello-ai/data-persistence-core':
+        specifier: workspace:*
+        version: link:../core
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+
+  libs/data-persistence/core:
+    dependencies:
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -266,10 +303,24 @@ importers:
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
-    devDependencies:
-      drizzle-kit:
-        specifier: ^0.28.0
-        version: 0.28.1
+
+  libs/data-persistence/session:
+    dependencies:
+      next:
+        specifier: ~16.1.6
+        version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+
+  libs/data-persistence/todo:
+    dependencies:
+      '@hello-ai/data-persistence-core':
+        specifier: workspace:*
+        version: link:../core
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
 
   libs/shared/design:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,6 @@ packages:
   - 'libs/shared/*'
   - 'libs/todo/*'
   - 'libs/data-persistence'
+  - 'libs/data-persistence/*'
 autoInstallPeers: true
 strictPeerDependencies: false

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,14 @@
       "@hello-ai/shared-design/*": ["libs/shared/design/src/*"],
       "@hello-ai/todo-data-access": ["libs/todo/data-access/src/index.ts"],
       "@hello-ai/todo-data-access/*": ["libs/todo/data-access/src/*"],
+      "@hello-ai/data-persistence-core": ["libs/data-persistence/core/src/index.ts"],
+      "@hello-ai/data-persistence-core/*": ["libs/data-persistence/core/src/*"],
+      "@hello-ai/data-persistence-chat": ["libs/data-persistence/chat/src/index.ts"],
+      "@hello-ai/data-persistence-chat/*": ["libs/data-persistence/chat/src/*"],
+      "@hello-ai/data-persistence-todo": ["libs/data-persistence/todo/src/index.ts"],
+      "@hello-ai/data-persistence-todo/*": ["libs/data-persistence/todo/src/*"],
+      "@hello-ai/data-persistence-session": ["libs/data-persistence/session/src/index.ts"],
+      "@hello-ai/data-persistence-session/*": ["libs/data-persistence/session/src/*"],
       "@hello-ai/data-persistence": ["libs/data-persistence/src/index.ts"],
       "@hello-ai/data-persistence/*": ["libs/data-persistence/src/*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,47 @@
   "compileOnSave": false,
   "files": [],
   "references": [
-    {"path": "./apps/joe-bot-e2e"},
-    {"path": "./apps/joe-bot"},
-    {"path": "./apps/todo-app-e2e"},
-    {"path": "./apps/todo-app"},
-    {"path": "./apps/landing-page-e2e"},
-    {"path": "./apps/landing-page"},
-    {"path": "./libs/shared/ui"},
-    {"path": "./libs/shared/design"},
-    {"path": "./libs/todo/data-access"},
-    {"path": "./libs/data-persistence"}
+    {
+      "path": "./apps/joe-bot-e2e"
+    },
+    {
+      "path": "./apps/joe-bot"
+    },
+    {
+      "path": "./apps/todo-app-e2e"
+    },
+    {
+      "path": "./apps/todo-app"
+    },
+    {
+      "path": "./apps/landing-page-e2e"
+    },
+    {
+      "path": "./apps/landing-page"
+    },
+    {
+      "path": "./libs/shared/ui"
+    },
+    {
+      "path": "./libs/shared/design"
+    },
+    {
+      "path": "./libs/todo/data-access"
+    },
+    {
+      "path": "./libs/data-persistence"
+    },
+    {
+      "path": "./libs/data-persistence/session"
+    },
+    {
+      "path": "./libs/data-persistence/chat"
+    },
+    {
+      "path": "./libs/data-persistence/core"
+    },
+    {
+      "path": "./libs/data-persistence/todo"
+    }
   ]
 }


### PR DESCRIPTION
Tighten Nx cache inputs and split the `data-persistence` library to improve CI cache hit rates.

This PR implements two strategies: first, it narrows the hashing inputs for `lint` and `build` tasks to prevent unnecessary cache invalidations from irrelevant file changes. Second, it refactors the monolithic `data-persistence` library into smaller, domain-specific libraries (`core`, `chat`, `todo`, `session`), reducing the dependency "blast radius" and ensuring that changes in one area do not invalidate tasks for unrelated applications.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-87a3e536-c14e-4168-966d-153d62b6d993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87a3e536-c14e-4168-966d-153d62b6d993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

