### PR TITLE
fix: add .nxignore so CI/config changes don't trigger affected builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           npx nx-cloud start-ci-run \
             --distribute-on=".nx/workflows/distribution-config.yaml" \
-            --stop-agents-after=build \
+            --stop-agents-after=lint,test,build \
             --stop-agents-on-failure \
             -- pnpm nx affected -t lint test build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,11 @@ jobs:
             echo "NX_BASE=origin/${{ github.base_ref || 'main' }}" >> $GITHUB_ENV
           fi
 
-      - name: Run lint, test, build (distributed via Nx Cloud compute)
+      - name: Run lint, test, build (distributed via Nx Cloud agents)
         run: |
           npx nx-cloud start-ci-run \
             --distribute-on=".nx/workflows/distribution-config.yaml" \
+            --stop-agents-after=build \
             --stop-agents-on-failure \
             -- pnpm nx affected -t lint test build
 

--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,3 @@
+# CI and workflow config changes shouldn't trigger affected builds
+.github/
+.nx/workflows/


### PR DESCRIPTION
Excludes `.github/` and `.nx/workflows/` from Nx affected calculations. Changes to CI or distribution config alone will no longer trigger unnecessary builds across all projects.

Made with [Cursor](https://cursor.com)