### PR TITLE
pr-naming-fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/playwright:v1.58.2-noble
     env:
-      NX_BRANCH: ${{ github.head_ref || github.ref_name }}
+      # PR number for pull_request (enables Nx Cloud GitHub integration: commit, author metadata); branch name for push
+      NX_BRANCH: ${{ github.event.pull_request.number || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fix NX_BRANCH: use PR number for pull_request events so Nx Cloud GitHub integration shows commit hash, message, and author metadata.

Made with [Cursor](https://cursor.com)