### PR TITLE
feat(joe-bot): add photo upload with OpenAI vision API

### DIFF
--- a/apps/joe-bot/next-env.d.ts
+++ b/apps/joe-bot/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/joe-bot/package.json
+++ b/apps/joe-bot/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "dependencies": {
     "@hello-ai/data-persistence": "workspace:*",
+    "@hello-ai/image-attachment-picker": "workspace:*",
     "@hello-ai/shared-design": "workspace:*",
     "@hello-ai/shared-ui": "workspace:*",
+    "@hello-ai/upload-utils": "workspace:*",
     "@libsql/client": "^0.14.0",
     "drizzle-orm": "^0.45.1",
     "next": "~16.1.6",

--- a/apps/joe-bot/src/app/global.css
+++ b/apps/joe-bot/src/app/global.css
@@ -2,6 +2,20 @@
 
 /* Ensure shared-ui component classes are included (Button, HomeLink, etc.) */
 @source "../../../../libs/shared/ui/src/**/*.{ts,tsx}";
+@source "../../../../libs/shared/image-attachment-picker/src/**/*.{ts,tsx}";
+
+/* Hide file input "Choose Files No file chosen" - native browser UI */
+input[type="file"][aria-label="Attach images"] {
+  position: absolute !important;
+  width: 0 !important;
+  height: 0 !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
 
 /* ---- Base document styles ---- */
 html,

--- a/apps/joe-bot/tailwind.config.js
+++ b/apps/joe-bot/tailwind.config.js
@@ -14,6 +14,7 @@ module.exports = {
   content: [
     './{src,pages,components,app}/**/*.{ts,tsx,js,jsx,html}',
     '../../libs/shared/ui/src/**/*.{ts,tsx}',
+    '../../libs/shared/image-attachment-picker/src/**/*.{ts,tsx}',
     '!./{src,pages,components,app}/**/*.{stories,spec}.{ts,tsx,js,jsx,html}',
     //     ...createGlobPatternsForDependencies(__dirname)
   ],

--- a/apps/joe-bot/tsconfig.json
+++ b/apps/joe-bot/tsconfig.json
@@ -11,8 +11,8 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "plugins": [{"name": "next"}],
-    "paths": {"@/*": ["./src/*"]},
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] },
     "types": ["jest", "node"],
     "outDir": "dist",
     "rootDir": "src",
@@ -27,6 +27,33 @@
     "../../dist/apps/joe-bot/.next/types/**/*.ts",
     "next-env.d.ts"
   ],
-  "exclude": ["out-tsc", "dist", "node_modules", "jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts", ".next", "eslint.config.js", "eslint.config.cjs", "eslint.config.mjs"],
-  "references": []
+  "exclude": [
+    "out-tsc",
+    "dist",
+    "node_modules",
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    ".next",
+    "eslint.config.js",
+    "eslint.config.cjs",
+    "eslint.config.mjs"
+  ],
+  "references": [
+    {
+      "path": "../../libs/upload-utils"
+    },
+    {
+      "path": "../../libs/shared/ui"
+    },
+    {
+      "path": "../../libs/shared/design"
+    },
+    {
+      "path": "../../libs/shared/image-attachment-picker"
+    },
+    {
+      "path": "../../libs/data-persistence"
+    }
+  ]
 }

--- a/apps/todo-app/tsconfig.json
+++ b/apps/todo-app/tsconfig.json
@@ -34,7 +34,16 @@
   ],
   "references": [
     {
-      "path": "../../shared"
+      "path": "../../libs/todo/data-access"
+    },
+    {
+      "path": "../../libs/shared/ui"
+    },
+    {
+      "path": "../../libs/shared/design"
+    },
+    {
+      "path": "../../libs/data-persistence"
     }
   ],
   "exclude": [

--- a/libs/shared/image-attachment-picker/package.json
+++ b/libs/shared/image-attachment-picker/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@hello-ai/image-attachment-picker",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@hello-ai/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@hello-ai/shared-design": "workspace:*",
+    "@hello-ai/shared-ui": "workspace:*",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  }
+}

--- a/libs/shared/image-attachment-picker/project.json
+++ b/libs/shared/image-attachment-picker/project.json
@@ -1,0 +1,10 @@
+{
+  "targets": {
+    "build": {
+      "inputs": ["production", "^production", { "externalDependencies": ["tslib", "react", "react-dom"] }]
+    },
+    "typecheck": {
+      "inputs": ["production", "^production", { "externalDependencies": ["tslib", "react", "react-dom"] }]
+    }
+  }
+}

--- a/libs/shared/image-attachment-picker/src/index.ts
+++ b/libs/shared/image-attachment-picker/src/index.ts
@@ -1,0 +1,2 @@
+export { ImageAttachmentPicker } from './image-attachment-picker';
+export type { ImageAttachmentPickerProps } from './image-attachment-picker';

--- a/libs/shared/image-attachment-picker/tsconfig.json
+++ b/libs/shared/image-attachment-picker/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/shared/image-attachment-picker/tsconfig.lib.json
+++ b/libs/shared/image-attachment-picker/tsconfig.lib.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [
+    {
+      "path": "../ui/tsconfig.lib.json"
+    },
+    {
+      "path": "../design/tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/upload-utils/package.json
+++ b/libs/upload-utils/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@hello-ai/upload-utils",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@hello-ai/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/libs/upload-utils/project.json
+++ b/libs/upload-utils/project.json
@@ -1,0 +1,10 @@
+{
+  "targets": {
+    "build": {
+      "inputs": ["production", "^production", { "externalDependencies": ["tslib"] }]
+    },
+    "typecheck": {
+      "inputs": ["production", "^production", { "externalDependencies": ["tslib"] }]
+    }
+  }
+}

--- a/libs/upload-utils/src/files-to-base64.ts
+++ b/libs/upload-utils/src/files-to-base64.ts
@@ -1,0 +1,14 @@
+/**
+ * Convert File objects to base64 data URLs for OpenAI vision API.
+ * Each URL is of the form: data:image/png;base64,{base64}
+ */
+export async function filesToBase64DataUrls(files: File[]): Promise<string[]> {
+  const results: string[] = [];
+  for (const file of files) {
+    const arrayBuffer = await file.arrayBuffer();
+    const base64 = Buffer.from(arrayBuffer).toString('base64');
+    const dataUrl = `data:${file.type};base64,${base64}`;
+    results.push(dataUrl);
+  }
+  return results;
+}

--- a/libs/upload-utils/src/index.ts
+++ b/libs/upload-utils/src/index.ts
@@ -1,0 +1,5 @@
+export { parseChatFormData } from './parse-form-data';
+export type { ParsedChatFormData } from './parse-form-data';
+export { validateImageFiles, ImageValidationError } from './validate-images';
+export type { ValidateImageOptions } from './validate-images';
+export { filesToBase64DataUrls } from './files-to-base64';

--- a/libs/upload-utils/src/parse-form-data.ts
+++ b/libs/upload-utils/src/parse-form-data.ts
@@ -1,0 +1,35 @@
+/**
+ * Parse a request body as either JSON (message only) or multipart/form-data (message + files).
+ * Used by chat API to support both text-only and image-attached messages.
+ */
+const CONTENT_TYPE_JSON = 'application/json';
+
+export type ParsedChatFormData =
+  | { format: 'json'; message: string; files: File[] }
+  | { format: 'multipart'; message: string; files: File[] };
+
+export async function parseChatFormData(req: Request): Promise<ParsedChatFormData> {
+  const contentType = req.headers.get('content-type') ?? '';
+
+  if (contentType.includes(CONTENT_TYPE_JSON)) {
+    const body = (await req.json()) as { message?: string };
+    const message = (body.message ?? '').trim();
+    return { format: 'json', message, files: [] };
+  }
+
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await req.formData();
+    const raw = formData.get('message');
+    const message = (typeof raw === 'string' ? raw : '').trim();
+    const files: File[] = [];
+    const entries = formData.getAll('files');
+    for (const entry of entries) {
+      if (entry instanceof File) {
+        files.push(entry);
+      }
+    }
+    return { format: 'multipart', message, files };
+  }
+
+  return { format: 'json', message: '', files: [] };
+}

--- a/libs/upload-utils/src/validate-images.ts
+++ b/libs/upload-utils/src/validate-images.ts
@@ -1,0 +1,57 @@
+/**
+ * Validate image attachments for chat uploads.
+ * Enforces count, size, and MIME type limits.
+ */
+
+const DEFAULT_MAX_COUNT = 4;
+const DEFAULT_MAX_BYTES = 1024 * 1024; // 1MB
+const DEFAULT_ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+export class ImageValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'TOO_MANY' | 'TOO_LARGE' | 'INVALID_TYPE'
+  ) {
+    super(message);
+    this.name = 'ImageValidationError';
+  }
+}
+
+export type ValidateImageOptions = {
+  maxCount?: number;
+  maxBytesPerFile?: number;
+  allowedTypes?: string[];
+};
+
+export function validateImageFiles(
+  files: File[],
+  opts: ValidateImageOptions = {}
+): void {
+  const maxCount = opts.maxCount ?? DEFAULT_MAX_COUNT;
+  const maxBytes = opts.maxBytesPerFile ?? DEFAULT_MAX_BYTES;
+  const allowed = new Set(opts.allowedTypes ?? DEFAULT_ALLOWED_TYPES);
+
+  if (files.length > maxCount) {
+    throw new ImageValidationError(
+      `Maximum ${maxCount} images allowed. You attached ${files.length}.`,
+      'TOO_MANY'
+    );
+  }
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (file.size > maxBytes) {
+      const mb = (maxBytes / (1024 * 1024)).toFixed(1);
+      throw new ImageValidationError(
+        `Image "${file.name}" is too large. Maximum ${mb}MB per file.`,
+        'TOO_LARGE'
+      );
+    }
+    if (!allowed.has(file.type)) {
+      throw new ImageValidationError(
+        `Image "${file.name}" has unsupported type "${file.type}". Allowed: jpeg, png, webp.`,
+        'INVALID_TYPE'
+      );
+    }
+  }
+}

--- a/libs/upload-utils/tsconfig.json
+++ b/libs/upload-utils/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/libs/upload-utils/tsconfig.lib.json
+++ b/libs/upload-utils/tsconfig.lib.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
       "!{projectRoot}/src/test-setup.[jt]s",
       "!{projectRoot}/test-setup.[jt]s"
     ],
-    "sharedGlobals": [{"runtime": "node -v"}, {"runtime": "pnpm -v"}]
+    "sharedGlobals": [{ "runtime": "node -v" }, { "runtime": "pnpm -v" }]
   },
   "nxCloudId": "68cd99327c8b4045e0d56253",
   "plugins": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,12 +171,18 @@ importers:
       '@hello-ai/data-persistence':
         specifier: workspace:*
         version: link:../../libs/data-persistence
+      '@hello-ai/image-attachment-picker':
+        specifier: workspace:*
+        version: link:../../libs/shared/image-attachment-picker
       '@hello-ai/shared-design':
         specifier: workspace:*
         version: link:../../libs/shared/design
       '@hello-ai/shared-ui':
         specifier: workspace:*
         version: link:../../libs/shared/ui
+      '@hello-ai/upload-utils':
+        specifier: workspace:*
+        version: link:../../libs/upload-utils
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -280,6 +286,24 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
 
+  libs/shared/image-attachment-picker:
+    dependencies:
+      '@hello-ai/shared-design':
+        specifier: workspace:*
+        version: link:../design
+      '@hello-ai/shared-ui':
+        specifier: workspace:*
+        version: link:../ui
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+
   libs/shared/ui:
     dependencies:
       tslib:
@@ -287,6 +311,12 @@ importers:
         version: 2.8.1
 
   libs/todo/data-access:
+    dependencies:
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+
+  libs/upload-utils:
     dependencies:
       tslib:
         specifier: ^2.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,6 @@ packages:
   - 'libs/shared/*'
   - 'libs/todo/*'
   - 'libs/data-persistence'
+  - 'libs/upload-utils'
 autoInstallPeers: true
 strictPeerDependencies: false

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,7 +26,15 @@
       "@hello-ai/todo-data-access": ["libs/todo/data-access/src/index.ts"],
       "@hello-ai/todo-data-access/*": ["libs/todo/data-access/src/*"],
       "@hello-ai/data-persistence": ["libs/data-persistence/src/index.ts"],
-      "@hello-ai/data-persistence/*": ["libs/data-persistence/src/*"]
+      "@hello-ai/data-persistence/*": ["libs/data-persistence/src/*"],
+      "@hello-ai/upload-utils": ["libs/upload-utils/src/index.ts"],
+      "@hello-ai/upload-utils/*": ["libs/upload-utils/src/*"],
+      "@hello-ai/image-attachment-picker": [
+        "libs/shared/image-attachment-picker/src/index.ts"
+      ],
+      "@hello-ai/image-attachment-picker/*": [
+        "libs/shared/image-attachment-picker/src/*"
+      ]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,41 @@
   "compileOnSave": false,
   "files": [],
   "references": [
-    {"path": "./apps/joe-bot-e2e"},
-    {"path": "./apps/joe-bot"},
-    {"path": "./apps/todo-app-e2e"},
-    {"path": "./apps/todo-app"},
-    {"path": "./apps/landing-page-e2e"},
-    {"path": "./apps/landing-page"},
-    {"path": "./libs/shared/ui"},
-    {"path": "./libs/shared/design"},
-    {"path": "./libs/todo/data-access"},
-    {"path": "./libs/data-persistence"}
+    {
+      "path": "./apps/joe-bot-e2e"
+    },
+    {
+      "path": "./apps/joe-bot"
+    },
+    {
+      "path": "./apps/todo-app-e2e"
+    },
+    {
+      "path": "./apps/todo-app"
+    },
+    {
+      "path": "./apps/landing-page-e2e"
+    },
+    {
+      "path": "./apps/landing-page"
+    },
+    {
+      "path": "./libs/shared/ui"
+    },
+    {
+      "path": "./libs/shared/design"
+    },
+    {
+      "path": "./libs/todo/data-access"
+    },
+    {
+      "path": "./libs/data-persistence"
+    },
+    {
+      "path": "./libs/shared/image-attachment-picker"
+    },
+    {
+      "path": "./libs/upload-utils"
+    }
   ]
 }


### PR DESCRIPTION
Allow users to attach photos to chat messages so Joe-bot can "see" them and respond with the OpenAI vision API.

## Changes
- **upload-utils lib**: Parse form data, validate images (max 4, 1MB each, jpeg/png/webp), convert to base64
- **image-attachment-picker lib**: Attach button (+ Attach photo), preview grid with remove
- **API**: Accept multipart/form-data, vision message format, system prompt tweak for images
- **Client**: ImageAttachmentPicker, FormData send, attachments state, canSend with images
- **History**: Store content with '· N photo(s)' suffix

Made with [Cursor](https://cursor.com)