### PR TITLE
fix: mobile photo upload

### DIFF
--- a/libs/shared/image-attachment-picker/package.json
+++ b/libs/shared/image-attachment-picker/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@hello-ai/shared-design": "workspace:*",
     "@hello-ai/shared-ui": "workspace:*",
+    "heic2any": "^0.0.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "tslib": "^2.3.0"

--- a/libs/shared/image-attachment-picker/src/image-attachment-picker.tsx
+++ b/libs/shared/image-attachment-picker/src/image-attachment-picker.tsx
@@ -60,27 +60,32 @@ export function ImageAttachmentPicker({
   );
 
   const accept = allowedTypes.join(',');
+  const inputId = React.useId();
+  const isDisabled = disabled || files.length >= maxCount;
 
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2 flex-wrap justify-start">
         <input
           ref={inputRef}
+          id={inputId}
           type="file"
           accept={accept}
           multiple
           onChange={handleSelect}
-          disabled={disabled || files.length >= maxCount}
-          className="!hidden"
+          disabled={isDisabled}
+          style={{ position: 'absolute', width: 1, height: 1, opacity: 0, overflow: 'hidden' }}
           aria-label="Attach images"
           tabIndex={-1}
         />
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={() => inputRef.current?.click()}
-          disabled={disabled || files.length >= maxCount}
+        <label
+          htmlFor={inputId}
+          className={cx(
+            'inline-flex items-center justify-center rounded-xl border font-medium shadow transition-all duration-150 cursor-pointer select-none',
+            'border-zinc-800 bg-zinc-950 text-zinc-300 hover:border-zinc-500 hover:bg-zinc-800 hover:text-zinc-100 active:scale-[0.98]',
+            'px-3 py-1.5 text-xs',
+            isDisabled && 'pointer-events-none opacity-40 cursor-not-allowed'
+          )}
           title={
             files.length >= maxCount
               ? `Maximum ${maxCount} images`
@@ -88,7 +93,7 @@ export function ImageAttachmentPicker({
           }
         >
           + Attach photo
-        </Button>
+        </label>
         {files.map((file, i) => (
           <div
             key={`${file.name}-${i}`}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       '@hello-ai/shared-ui':
         specifier: workspace:*
         version: link:../ui
+      heic2any:
+        specifier: ^0.0.4
+        version: 0.0.4
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -5646,6 +5649,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  heic2any@0.0.4:
+    resolution: {integrity: sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -14699,6 +14705,8 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  heic2any@0.0.4: {}
 
   hermes-estree@0.25.1: {}
 


### PR DESCRIPTION
Fix photo upload on mobile (Safari/iOS) by using a label instead of programmatic click().

- Replace Button + inputRef.click() with label htmlFor - mobile browsers block programmatic file input activation
- Use 1x1 opacity:0 input instead of display:none for better mobile compatibility

Made with [Cursor](https://cursor.com)