### PR TITLE
Fix HEIC/HEIF photo upload from iPhone

### DIFF
--- a/apps/joe-bot/src/app/page.tsx
+++ b/apps/joe-bot/src/app/page.tsx
@@ -311,10 +311,14 @@ export default function Page() {
             <div className="mb-2 flex justify-start">
               <ImageAttachmentPicker
                 files={attachments}
-                onChange={setAttachments}
+                onChange={(files) => {
+                  setError(null);
+                  setAttachments(files);
+                }}
                 maxCount={4}
-                maxBytesPerFile={1024 * 1024}
+                maxBytesPerFile={5 * 1024 * 1024}
                 disabled={isSending}
+                onConversionError={setError}
               />
             </div>
             <div className="flex gap-2">


### PR DESCRIPTION
Fixes photo attachments from iPhone that weren't working:

- **5MB limit**: page.tsx was still passing 1MB; now uses 5MB
- **HEIF support**: Added image/heif-sequence, image/heic-sequence, .hif/.heics/.heifs
- **Empty-type fallback**: iOS often gives empty file.type for HEIC/HEIF; try conversion anyway
- **Error feedback**: onConversionError callback shows guidance when heic2any fails (Safari known issue)

Made with [Cursor](https://cursor.com)